### PR TITLE
Fix fling up behavior

### DIFF
--- a/appbarsnapbehavior/src/main/java/com/github/godness84/appbarsnapbehavior/AppBarSnapBehavior.java
+++ b/appbarsnapbehavior/src/main/java/com/github/godness84/appbarsnapbehavior/AppBarSnapBehavior.java
@@ -78,19 +78,6 @@ public class AppBarSnapBehavior extends CoordinatorLayout.Behavior<AppBarLayout>
 
     @Override
     public void onNestedPreScroll(CoordinatorLayout coordinatorLayout, AppBarLayout child, View target, int dx, int dy, int[] consumed) {
-        if (dy < 0)
-            return;
-
-        View parent = getParentViewWithBehavior(coordinatorLayout, target);
-        if (parent == null) {
-            return;
-        }
-
-        ScrollingViewBehavior behavior = (ScrollingViewBehavior) ((CoordinatorLayout.LayoutParams) parent.getLayoutParams()).getBehavior();
-        if (!behavior.canScrollUp()) {
-            return;
-        }
-
         int offset = scroll(child, dy);
 
         if (offset != 0) {

--- a/appbarsnapbehavior/src/main/java/com/github/godness84/appbarsnapbehavior/ScrollingViewBehavior.java
+++ b/appbarsnapbehavior/src/main/java/com/github/godness84/appbarsnapbehavior/ScrollingViewBehavior.java
@@ -84,16 +84,15 @@ public class ScrollingViewBehavior extends CoordinatorLayout.Behavior<View> {
 
     @Override
     public void onNestedPreScroll(CoordinatorLayout coordinatorLayout, View child, View target, int dx, int dy, int[] consumed) {
-        if (dy > 0 && child.getTop() > mOriginalTop - mAppBarLayout.getTotalScrollRange()) {
+        if ((dy > 0 && child.getTop() > mOriginalTop - mAppBarLayout.getTotalScrollRange()) ||
+                (dy < 0 && child.getTop() < mOriginalTop)) {
             consumed[1] = scroll(child, dy);
         }
     }
 
     @Override
     public void onNestedScroll(CoordinatorLayout coordinatorLayout, View child, View target, int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed) {
-        if (dyUnconsumed < 0) {
-            scroll(child, dyUnconsumed);
-        }
+
     }
 
     @Override


### PR DESCRIPTION
Fixes the problem where when the scrollview is at the bottom and the user flings down, the scrollview scrolls up but not to the top, because the child.top is set to the wrong height (0 instead of appbar.height).
